### PR TITLE
Fixed NullOrWhiteSpace check for 'Line 2' in address fields

### DIFF
--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -65,7 +65,7 @@ namespace Vendr.PaymentProviders.Stripe
                     {
                         Line1 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine1PropertyAlias)
                             ? order.Properties[settings.BillingAddressLine1PropertyAlias] : "",
-                        Line2 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine1PropertyAlias)
+                        Line2 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine2PropertyAlias)
                             ? order.Properties[settings.BillingAddressLine2PropertyAlias] : "",
                         City = !string.IsNullOrWhiteSpace(settings.BillingAddressCityPropertyAlias)
                             ? order.Properties[settings.BillingAddressCityPropertyAlias] : "",
@@ -99,7 +99,7 @@ namespace Vendr.PaymentProviders.Stripe
                     {
                         Line1 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine1PropertyAlias)
                         ? order.Properties[settings.BillingAddressLine1PropertyAlias] : "",
-                        Line2 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine1PropertyAlias)
+                        Line2 = !string.IsNullOrWhiteSpace(settings.BillingAddressLine2PropertyAlias)
                         ? order.Properties[settings.BillingAddressLine2PropertyAlias] : "",
                         City = !string.IsNullOrWhiteSpace(settings.BillingAddressCityPropertyAlias)
                         ? order.Properties[settings.BillingAddressCityPropertyAlias] : "",


### PR DESCRIPTION
While integrating Stripe into one of our project we've noticed (kudos Adrian!) that a null check for the Line2 was performed against Line1 in address. It's working as usually no one is placing second line without the first one, but... there is still that possibility.

Small fix with the proper properties checked here!

Viva Hacktoberfest :)