### PR TITLE
Adding options to disable automatic tax calculation and the subscription tax

### DIFF
--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -166,14 +166,19 @@ namespace Vendr.PaymentProviders.Stripe
                     // the quantity of the stripe price you want to buy.
                     lineItemOpts.Quantity = (long)orderLine.Quantity;
 
-                    // Because we are in charge of what taxes apply, we need to setup a tax rate
-                    // to ensure the price defined in stripe has the relevant taxes applied
-                    var stripePricesIncludeTax = PropertyIsTrue(orderLine.Properties, "stripePriceIncludesTax");
-                    var stripeTaxRate = GetOrCreateStripeTaxRate(ctx, "Subscription Tax", orderLineTaxRate, stripePricesIncludeTax);
-                    if (stripeTaxRate != null)
+
+                    if (!ctx.Settings.DisableSubscriptionTax)
                     {
-                        lineItemOpts.TaxRates = new List<string>(new[] { stripeTaxRate.Id });
+                        // Because we are in charge of what taxes apply, we need to setup a tax rate
+                        // to ensure the price defined in stripe has the relevant taxes applied
+                        var stripePricesIncludeTax = PropertyIsTrue(orderLine.Properties, "stripePriceIncludesTax");
+                        var stripeTaxRate = GetOrCreateStripeTaxRate(ctx, "Subscription Tax", orderLineTaxRate, stripePricesIncludeTax);
+                        if (stripeTaxRate != null)
+                        {
+                            lineItemOpts.TaxRates = new List<string>(new[] { stripeTaxRate.Id });
+                        }
                     }
+
                 }
                 else
                 {
@@ -213,14 +218,18 @@ namespace Vendr.PaymentProviders.Stripe
                     // as a single subscription item with one price being the line items total price
                     lineItemOpts.Quantity = (long)orderLine.Quantity;
 
-                    // If we define the price, then create tax rates that are set to be inclusive
-                    // as this means that we can pass prices inclusive of tax and Stripe works out
-                    // the pre-tax price which would be less suseptable to rounding inconsistancies
-                    var stripeTaxRate = GetOrCreateStripeTaxRate(ctx, "Subscription Tax", orderLineTaxRate, false);
-                    if (stripeTaxRate != null)
+                    if (!ctx.Settings.DisableSubscriptionTax)
                     {
-                        lineItemOpts.TaxRates = new List<string>(new[] { stripeTaxRate.Id });
+                        // If we define the price, then create tax rates that are set to be inclusive
+                        // as this means that we can pass prices inclusive of tax and Stripe works out
+                        // the pre-tax price which would be less suseptable to rounding inconsistancies
+                        var stripeTaxRate = GetOrCreateStripeTaxRate(ctx, "Subscription Tax", orderLineTaxRate, false);
+                        if (stripeTaxRate != null)
+                        {
+                            lineItemOpts.TaxRates = new List<string>(new[] { stripeTaxRate.Id });
+                        }
                     }
+
                 }
 
                 lineItems.Add(lineItemOpts);
@@ -299,6 +308,14 @@ namespace Vendr.PaymentProviders.Stripe
             if (ctx.Settings.SendStripeReceipt)
             {
                 sessionOptions.PaymentIntentData.ReceiptEmail = ctx.Order.CustomerInfo.Email;
+            }
+
+            if (ctx.Settings.DisableAutomaticTax)
+            {
+                sessionOptions.AutomaticTax = new SessionAutomaticTaxOptions()
+                {
+                    Enabled = false
+                };
             }
 
             var sessionService = new SessionService();

--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutSettings.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutSettings.cs
@@ -33,5 +33,18 @@ namespace Vendr.PaymentProviders.Stripe
             IsAdvanced = true,
             SortOrder = 1000400)]
         public string PaymentMethodTypes { get; set; }
+
+        [PaymentProviderSetting(Name = "Disable Automatic Tax Calculation",
+            Description = "Flag indicating whether Stripe should automatically calculate tax on a checkout session. Ensure 'Enable automatic tax calculation' is disabled from the stripe dashboard settings.",
+            IsAdvanced = true,
+            SortOrder = 1000500)]
+        public bool DisableAutomaticTax { get; set; }
+
+
+        [PaymentProviderSetting(Name = "Disable Subscription Tax",
+            Description = "Flag indicating whether to disable the 'Subscription Tax' from being added by default to recurring subscription products based on the order line tax rate.",
+            IsAdvanced = true,
+            SortOrder = 1000600)]
+        public bool DisableSubscriptionTax { get; set; }
     }
 }


### PR DESCRIPTION
This commit adds additional options to allow users to disable stripe from automatically calculating tax upon creation of a checkout session, along with also giving an option to bypass the default subscription tax which is currently added.