### PR TITLE
Update Stripe SDK to v41

### DIFF
--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -371,7 +371,7 @@ namespace Vendr.PaymentProviders.Stripe
                                 { "stripePaymentIntentId", stripeSession.PaymentIntentId },
                                 { "stripeSubscriptionId", stripeSession.SubscriptionId },
                                 { "stripeChargeId", GetTransactionId(paymentIntent) },
-                                { "stripeCardCountry", paymentIntent.Charges?.Data?.FirstOrDefault()?.PaymentMethodDetails?.Card?.Country }
+                                { "stripeCardCountry", paymentIntent.LatestCharge?.PaymentMethodDetails?.Card?.Country }
                             });
                         }
                         else if (stripeSession.Mode == "subscription")
@@ -524,7 +524,7 @@ namespace Vendr.PaymentProviders.Stripe
                     MetaData = new Dictionary<string, string>
                     {
                         { "stripeChargeId", GetTransactionId(paymentIntent) },
-                        { "stripeCardCountry", paymentIntent.Charges?.Data?.FirstOrDefault()?.PaymentMethodDetails?.Card?.Country }
+                        { "stripeCardCountry", paymentIntent.LatestCharge?.PaymentMethodDetails?.Card?.Country }
                     }
                 };
             }

--- a/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
@@ -224,9 +224,7 @@ namespace Vendr.PaymentProviders.Stripe
 
         protected string GetTransactionId(PaymentIntent paymentIntent)
         {
-            return (paymentIntent.Charges?.Data?.Count ?? 0) > 0
-                ? GetTransactionId(paymentIntent.Charges.Data[0])
-                : null;
+            return GetTransactionId(paymentIntent.LatestCharge);
         }
 
         protected string GetTransactionId(Invoice invoice)
@@ -294,9 +292,9 @@ namespace Vendr.PaymentProviders.Stripe
 
             if (paymentIntent.Status == "succeeded")
             {
-                if (paymentIntent.Charges.Data.Any())
+                if (paymentIntent.LatestCharge != null)
                 {
-                    return GetPaymentStatus(paymentIntent.Charges.Data[0]);
+                    return GetPaymentStatus(paymentIntent.LatestCharge);
                 }
                 else
                 {

--- a/src/Vendr.PaymentProviders.Stripe/Vendr.PaymentProviders.Stripe.csproj
+++ b/src/Vendr.PaymentProviders.Stripe/Vendr.PaymentProviders.Stripe.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stripe.net" Version="39.61.0" />
+    <PackageReference Include="Stripe.net" Version="41.0.0" />
     <PackageReference Include="Vendr.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
   </ItemGroup>


### PR DESCRIPTION
Stripe [SDK v41](https://github.com/stripe/stripe-dotnet/releases/tag/v41.0.0) includes some breaking changes.

Vendr doesn't have an upper dependency version limit for the SDK, so this caused us problems in production.

This PR updates the minimum version to v41, and changes from the `Charges` collection to `LatestCharge` property.