### PR TITLE
Missing transaction IDs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ trigger:
 variables:
   - group: 'vendr'
   - name: 'vmImageName'
-    value: 'vs2017-win2016'
+    value: 'windows-latest'
   - name: 'nuGetOrgServiceCreds'
     value: 'NuGet.org (Vendr)'
   - name: 'packageName'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,11 @@ stages:
         displayName: 'Build'
         dependsOn: [ ]
         steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk 5.0.x'
+            inputs:
+               version: 5.0.x
+               # includePreviewVersions: true
           - task: CmdLine@2
             inputs:
               script: './build.cmd Pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,10 @@ stages:
             displayName: 'Use .NET Core sdk 5.0.x'
             inputs:
                version: 5.0.x
-               # includePreviewVersions: true
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core sdk 3.0.x'
+            inputs:
+               version: 3.0.x
           - task: CmdLine@2
             inputs:
               script: './build.cmd Pack'

--- a/build/_build.csproj.DotSettings
+++ b/build/_build.csproj.DotSettings
@@ -1,4 +1,4 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeapView_002EDelegateAllocation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VariableHidesOuterVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -20,6 +20,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>

--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -371,7 +371,7 @@ namespace Vendr.PaymentProviders.Stripe
                                 { "stripePaymentIntentId", stripeSession.PaymentIntentId },
                                 { "stripeSubscriptionId", stripeSession.SubscriptionId },
                                 { "stripeChargeId", GetTransactionId(paymentIntent) },
-                                { "stripeCardCountry", paymentIntent.Charges?.Data?.FirstOrDefault()?.PaymentMethodDetails?.Card?.Country }
+                                { "stripeCardCountry", paymentIntent.LatestCharge?.PaymentMethodDetails?.Card?.Country }
                             });
                         }
                         else if (stripeSession.Mode == "subscription")
@@ -524,7 +524,7 @@ namespace Vendr.PaymentProviders.Stripe
                     MetaData = new Dictionary<string, string>
                     {
                         { "stripeChargeId", GetTransactionId(paymentIntent) },
-                        { "stripeCardCountry", paymentIntent.Charges?.Data?.FirstOrDefault()?.PaymentMethodDetails?.Card?.Country }
+                        { "stripeCardCountry", paymentIntent.LatestCharge?.PaymentMethodDetails?.Card?.Country }
                     }
                 };
             }

--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -354,7 +354,9 @@ namespace Vendr.PaymentProviders.Stripe
                             var paymentIntentService = new PaymentIntentService();
                             var paymentIntent = await paymentIntentService.GetAsync(stripeSession.PaymentIntentId, new PaymentIntentGetOptions
                             {
-                                Expand = new List<string>(new[] {
+                                Expand = new List<string>(new[]
+                                {
+                                    "latest_charge",
                                     "review"
                                 })
                             });
@@ -378,8 +380,10 @@ namespace Vendr.PaymentProviders.Stripe
                         else if (stripeSession.Mode == "subscription")
                         {
                             var subscriptionService = new SubscriptionService();
-                            var subscription = await subscriptionService.GetAsync(stripeSession.SubscriptionId, new SubscriptionGetOptions { 
-                                Expand = new List<string>(new[] { 
+                            var subscription = await subscriptionService.GetAsync(stripeSession.SubscriptionId, new SubscriptionGetOptions
+                            { 
+                                Expand = new List<string>(new[]
+                                { 
                                     "latest_invoice",
                                     "latest_invoice.charge",
                                     "latest_invoice.charge.review",
@@ -412,8 +416,10 @@ namespace Vendr.PaymentProviders.Stripe
                         {
                             var paymentIntentService = new PaymentIntentService();
                             var paymentIntent = paymentIntentService.Get(stripeReview.PaymentIntentId, new PaymentIntentGetOptions
+                            {
+                                Expand = new List<string>(new[]
                                 {
-                                    Expand = new List<string>(new[] {
+                                    "latest_charge",
                                     "review"
                                 })
                             });
@@ -451,7 +457,9 @@ namespace Vendr.PaymentProviders.Stripe
                     var paymentIntentService = new PaymentIntentService();
                     var paymentIntent = await paymentIntentService.GetAsync(paymentIntentId, new PaymentIntentGetOptions
                     {
-                        Expand = new List<string>(new[] {
+                        Expand = new List<string>(new[]
+                        {
+                            "latest_charge",
                             "review"
                         })
                     });

--- a/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripeCheckoutPaymentProvider.cs
@@ -277,7 +277,8 @@ namespace Vendr.PaymentProviders.Stripe
                     : "payment",
                 ClientReferenceId = ctx.Order.GenerateOrderReference(),
                 SuccessUrl = ctx.Urls.ContinueUrl,
-                CancelUrl = ctx.Urls.CancelUrl
+                CancelUrl = ctx.Urls.CancelUrl,
+                Locale = FindBestMatchSupportedLocale(ctx.Order.LanguageIsoCode)
             };
 
             if (hasRecurringItems)

--- a/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
@@ -224,9 +224,7 @@ namespace Vendr.PaymentProviders.Stripe
 
         protected string GetTransactionId(PaymentIntent paymentIntent)
         {
-            return (paymentIntent.Charges?.Data?.Count ?? 0) > 0
-                ? GetTransactionId(paymentIntent.Charges.Data[0])
-                : null;
+            return GetTransactionId(paymentIntent.LatestCharge);
         }
 
         protected string GetTransactionId(Invoice invoice)
@@ -294,9 +292,9 @@ namespace Vendr.PaymentProviders.Stripe
 
             if (paymentIntent.Status == "succeeded")
             {
-                if (paymentIntent.Charges.Data.Any())
+                if (paymentIntent.LatestCharge != null)
                 {
-                    return GetPaymentStatus(paymentIntent.Charges.Data[0]);
+                    return GetPaymentStatus(paymentIntent.LatestCharge);
                 }
                 else
                 {

--- a/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
@@ -22,7 +22,8 @@ namespace Vendr.PaymentProviders.Stripe
     {
         protected readonly ILogger<TSelf> _logger;
 
-        private static string[] SUPPORTED_LOCALES = new[]{
+        private static string[] SUPPORTED_LOCALES = new[]
+        {
             "bg","cs","da","de","el","en",
             "en-GB","es","es-419","et","fi","fil",
             "fr","fr-CA","hr","hu","id","it",
@@ -234,12 +235,12 @@ namespace Vendr.PaymentProviders.Stripe
 
         protected string GetTransactionId(PaymentIntent paymentIntent)
         {
-            return GetTransactionId(paymentIntent.LatestCharge);
+            return paymentIntent?.LatestChargeId;
         }
 
         protected string GetTransactionId(Invoice invoice)
         {
-            return GetTransactionId(invoice.Charge);
+            return invoice?.ChargeId;
         }
 
         protected string GetTransactionId(Charge charge)

--- a/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
+++ b/src/Vendr.PaymentProviders.Stripe/StripePaymentProviderBase.cs
@@ -22,6 +22,16 @@ namespace Vendr.PaymentProviders.Stripe
     {
         protected readonly ILogger<TSelf> _logger;
 
+        private static string[] SUPPORTED_LOCALES = new[]{
+            "bg","cs","da","de","el","en",
+            "en-GB","es","es-419","et","fi","fil",
+            "fr","fr-CA","hr","hu","id","it",
+            "ja","ko","lt","lv","ms","mt",
+            "nb","nl","pl","pt","pt-BR","ro",
+            "ru","sk","sl","sv","th","tr",
+            "vi","zh","zh-HK","zh-TW"
+        };
+
         public StripePaymentProviderBase(VendrContext vendr,
             ILogger<TSelf> logger)
             : base(vendr)
@@ -337,6 +347,20 @@ namespace Vendr.PaymentProviders.Stripe
             }
 
             return paymentState;
+        }
+
+        protected string FindBestMatchSupportedLocale(string locale)
+        {
+            var exactMatch = SUPPORTED_LOCALES.FirstOrDefault(x => x.Equals(locale, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(exactMatch))
+                return exactMatch;
+
+            var countryLocale = locale.Split(new[] { '-' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            var subMatch = SUPPORTED_LOCALES.FirstOrDefault(x => x.Equals(countryLocale, StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrWhiteSpace(subMatch))
+                return subMatch;
+
+            return "auto";
         }
     }
 }

--- a/src/Vendr.PaymentProviders.Stripe/Vendr.PaymentProviders.Stripe.csproj
+++ b/src/Vendr.PaymentProviders.Stripe/Vendr.PaymentProviders.Stripe.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stripe.net" Version="39.61.0" />
+    <PackageReference Include="Stripe.net" Version="41.0.0" />
     <PackageReference Include="Vendr.Core" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
   </ItemGroup>


### PR DESCRIPTION
Welp, looks like I broke things in #12... We've been seeing missing transaction IDs since rolling that update out. Oops!

The Stripe SDK requires you expand the `latest_charge` property to actually load that data, so this was always returning null (and thus not setting the transaction ID).

Meanwhile I also noticed payment intents and invoices have the charge ID properties set directly, so we can just use that instead. We still need to expand the charge property though as it's used elsewhere.